### PR TITLE
Added definitions for TRUE and FALSE for macOS

### DIFF
--- a/src/ipr.h
+++ b/src/ipr.h
@@ -10,6 +10,13 @@
 #include "utils/inet.h"
 #include "utils/palloc.h"
 
+#if !defined(TRUE)
+#define TRUE 1
+#endif
+#if !defined(FALSE)
+#define FALSE 0
+#endif
+
 #if !defined(PG_VERSION_NUM)
 #error "Unknown or unsupported postgresql version"
 #endif


### PR DESCRIPTION
I installed PostgreSQL@11 and pex using brew on macOS Catalina 10.5.3. Then, when I tried to install ip4r with pex, the compilation failed because FALSE and TRUE were not defined in the includes found in the include path. So I just added those simple definitions, and it allowed to build and install.