### PR TITLE
Remove the newline for the call function

### DIFF
--- a/tools/numeric.mk
+++ b/tools/numeric.mk
@@ -15,9 +15,7 @@ $(if $(strip $(1)),
                t,
                $(if $(call numeric_lt,$(firstword $(1)),$(firstword $(2))),
                     ,
-                    $(call vge_2,
-                           $(wordlist 2,$(words $(1)),$(1)),
-                           $(wordlist 2,$(words $(2)),$(2))))),
+                    $(call vge_2,$(wordlist 2,$(words $(1)),$(1)),$(wordlist 2,$(words $(2)),$(2))))),
           t),
      $(if $(strip $(2)),,t))
 endef
@@ -30,6 +28,22 @@ numeric_lt = $(if $(call numeric_le,$(2),$(1)),,t)
 
 # list of N words
 nwords = $(if $(filter-out 0,$(1)),$(if $(word $(1),$(2)),$(2),$(call nwords,$(1),$(2) t)))
+
+define assert
+$(if $1,,$(error assert failed: $2))
+endef
+
+define assert_n
+$(if $1,$(error assert_n failed: $2),)
+endef
+
+.PHONY: test_tools_numeric
+
+tools_test_numeric:
+    $(call assert_n,$(call version_ge,9.0,9.1))
+    $(call assert,$(call version_ge,9.2,9.1))
+    $(call assert,$(call version_ge,9.0,9.0))
+    $(call assert_n,$(call version_ge,9.4,13))
 
 ## end of hacks.
 ##--


### PR DESCRIPTION
If we add the newline in call arguments. Then the newline and leading whitespaces will be treated as part of the arguments. The `words` and `firstword` functions in GNU make 3.82 will treat newline as word separator while GNU make 4.3 won't. This results the function "nwords` will report error like: "first argument to `word' function must be greater than 0.  Stop."

Add testcase for the functions in numeric.

This is a test:

```makefile
define assert
$(if $1,,$(error assert failed: $2))
endef

define assert_n
$(if $1,$(error assert_n failed: $2),)
endef

# $(call version_ge,a,b)
#  true iff a >= b when treated as vectors of integers separated by . or space
version_ge = $(strip $(call vge_2,$(subst ., ,$(1)),$(subst ., ,$(2))))

define vge_2
$(info [vge_2].arg1="$(1)" strip1="$(strip $1)" words1="$(words $(1))" firstword1="$(firstword $(1))")
$(info [vge_2].arg2="$(2)" strip2="$(strip $2)" words2="$(words $(2))" firstword2="$(firstword $(2))")
$(if $(strip $(1)),
     $(if $(strip $(2)),
          $(if $(call numeric_lt,$(firstword $(2)),$(firstword $(1))),
               t,
               $(if $(call numeric_lt,$(firstword $(1)),$(firstword $(2))),
                    ,
                    $(call vge_2,
                           $(wordlist 2,$(words $(1)),$(1)),
                           $(wordlist 2,$(words $(2)),$(2))))),
          t),
     $(if $(strip $(2)),,t))
endef

# $(call numeric_le,a,b)  - true if a <= b, i.e. either a is 0 or a can index a [1..b] list
numeric_le = $(if $(filter 0,$(1)),t,$(word $(1),$(call nwords,$(2),)))

# $(call numeric_lt,a,b)  - true if a < b, i.e. !(b <= a)
numeric_lt = $(if $(call numeric_le,$(2),$(1)),,t)

# list of N words
nwords = $(if $(filter-out 0,$(1)),$(if $(word $(1),$(2)),$(2),$(call nwords,$(1),$(2) t)))

## end of hacks.
##--

define mystr

 1
endef

.PHONY: test_numeric

test_numeric:
    $(info words_str="$(words $(mystr))")
    $(info first_word="$(firstword $(mystr))")
    $(call assert_n,$(call version_ge,9.0,9.1))
```

The output is:

```shell
GNU Make 4.3
Built for x86_64-redhat-linux-gnu
Copyright (C) 1988-2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
words_str="1"
first_word="1"
[vge_2].arg1="9 0" strip1="9 0" words1="2" firstword1="9"
[vge_2].arg2="9 1" strip2="9 1" words2="2" firstword2="9"
[vge_2].arg1="
                           0" strip1="0" words1="1" firstword1="0"
[vge_2].arg2="
                           1" strip2="1" words2="1" firstword2="1"
make: Nothing to be done for 'test_numeric'.
++++++++++++++++++++++++
GNU Make 3.82
Built for x86_64-redhat-linux-gnu
Copyright (C) 2010  Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
words_str="2"
first_word="
"
[vge_2].arg1="9 0" strip1="9 0" words1="2" firstword1="9"
[vge_2].arg2="9 1" strip2="9 1" words2="2" firstword2="9"
[vge_2].arg1="
                           0" strip1="0" words1="2" firstword1="
"
[vge_2].arg2="
                           1" strip2="1" words2="2" firstword2="
"
numeric.mk:39: *** first argument to `word' function must be greater than 0.  Stop.
```