### PR TITLE
Support PostgreSQL 19

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -17,10 +17,10 @@ jobs:
 
     strategy:
       matrix:
-        pgver:  [ 9.5, 9.6, 10, 11, 12, 13, 14, 15, 16 ]
+        pgver:  [ 9.5, 9.6, 10, 11, 12, 13, 14, 15, 16, 17, 18 ]
         include:
           - pgrepo: ""
-          - pgver: 17
+          - pgver: 19
             pgrepo: "-pgdg-snapshot"
 
     env:
@@ -36,7 +36,7 @@ jobs:
         sudo apt-get -y --purge --no-upgrade remove postgresql libpq-dev libpq5 postgresql-client-common postgresql-common
         curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
         sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" >/etc/apt/sources.list.d/pgdg.list'
-        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg-snapshot main 17" >/etc/apt/sources.list.d/pgdg-snap.list'
+        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg-snapshot main 19" >/etc/apt/sources.list.d/pgdg-snap.list'
         sudo apt-get update -qq
         sudo rm -rf /var/lib/postgresql
 

--- a/src/ip4r.c
+++ b/src/ip4r.c
@@ -372,7 +372,7 @@ ip4_cast_from_bit(PG_FUNCTION_ARGS)
 
 	if (val->bit_len == 32)
 	{
-		bits8 *p = VARBITS(val);
+		uint8 *p = VARBITS(val);
 		IP4 ip = (p[0] << 24)|(p[1] << 16)|(p[2] << 8)|p[3];
 		PG_RETURN_IP4(ip);
 	}
@@ -869,8 +869,8 @@ ip4r_cast_from_bit(PG_FUNCTION_ARGS)
 
 	if (bitlen <= 32)
 	{
-		bits8 buf[4];
-		bits8 *p = VARBITS(val);
+		uint8 buf[4];
+		uint8 *p = VARBITS(val);
 		IP4 ip;
 		IP4R *res = palloc(sizeof(IP4R));
 

--- a/src/ip6r.c
+++ b/src/ip6r.c
@@ -375,7 +375,7 @@ ip6_cast_from_bit(PG_FUNCTION_ARGS)
 
 	if (VARBITLEN(val) == 128)
 	{
-		bits8 *p = VARBITS(val);
+		uint8 *p = VARBITS(val);
 		IP6 *res = palloc(sizeof(IP6));
 		ip6_deserialize(p, res);
 		PG_RETURN_IP6_P(res);
@@ -942,8 +942,8 @@ ip6r_cast_from_bit(PG_FUNCTION_ARGS)
 
 	if (bitlen <= 128)
 	{
-		bits8 buf[16];
-		bits8 *p = VARBITS(val);
+		uint8 buf[16];
+		uint8 *p = VARBITS(val);
 		IP6 ip;
 		IP6R *res = palloc(sizeof(IP6R));
 

--- a/src/ipr.h
+++ b/src/ipr.h
@@ -21,6 +21,17 @@
 #include "varatt.h"
 #endif
 
+#if PG_VERSION_NUM < 190000
+/* a copy of the PostgreSQL macro for -Wimplicit-fallthrough level 5 */
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L) || (defined(__cplusplus) && __cplusplus >= 201703L)
+#define pg_fallthrough [[fallthrough]]
+#elif __has_attribute(fallthrough)
+#define pg_fallthrough __attribute__((fallthrough))
+#else
+#define pg_fallthrough
+#endif
+#endif
+
 #ifndef PGDLLEXPORT
 #define PGDLLEXPORT
 #endif

--- a/src/raw_io.c
+++ b/src/raw_io.c
@@ -115,6 +115,7 @@ bool ip6_raw_input(const char *osrc, uint64 *dst)
 				}
 
 				/* FALLTHROUGH */
+				pg_fallthrough;
 			case 0:
 				if (digits)
 					tmp[words++] = word;


### PR DESCRIPTION
1. https://github.com/postgres/postgres/commit/bab2f27eaaad77f799ecc224f9e11b09adb07d5a removed `bits8` type. Fixed by switching to `uint8`.
2. -Wimplicit-fallthrough level 5 results in compile warnings. Fixed by using pg_fallthrough macro. For older major versions copied macro into src/ipr.h